### PR TITLE
use webidl-util gradle plugin to generate physx js bindings

### DIFF
--- a/buildSrc/src/main/kotlin/de/fabmax/kool/LocalProperties.kt
+++ b/buildSrc/src/main/kotlin/de/fabmax/kool/LocalProperties.kt
@@ -13,9 +13,13 @@ class LocalProperties private constructor(file: File) : Properties() {
 
     operator fun get(key: String): String? = getProperty(key, System.getenv(key))
 
+    fun getOrElse(key: String, default: String) = get(key) ?: default
+
     companion object {
         fun get(project: Project): LocalProperties {
             return LocalProperties(project.rootProject.file("local.properties"))
         }
     }
 }
+
+val Project.localProperties: LocalProperties get() = LocalProperties.get(this)

--- a/buildSrc/src/main/kotlin/de/fabmax/kool/VersionNameUpdate.kt
+++ b/buildSrc/src/main/kotlin/de/fabmax/kool/VersionNameUpdate.kt
@@ -1,6 +1,6 @@
 package de.fabmax.kool
 
-import LocalProperties
+import localProperties
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -22,7 +22,7 @@ open class VersionNameUpdate : DefaultTask() {
             val text = file.readText()
             val lineSep = if ("\r\n" in text) "\r\n" else "\n"
 
-            if (LocalProperties.get(project).isRelease) {
+            if (project.localProperties.isRelease) {
                 var updated = false
                 val lines = text.lines().toMutableList()
                 for (i in lines.indices) {

--- a/kool-demo/build.gradle.kts
+++ b/kool-demo/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
                 outputDirectory.set(File("${rootDir}/dist/kool-demo"))
             }
             commonWebpackConfig {
-                mode = if (LocalProperties.get(project).isRelease) {
+                mode = if (localProperties.isRelease) {
                     KotlinWebpackConfig.Mode.PRODUCTION
                 } else {
                     KotlinWebpackConfig.Mode.DEVELOPMENT

--- a/kool-physics/build.gradle.kts
+++ b/kool-physics/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     id("kool.lib-conventions")
     id("kool.publish-conventions")
+
+    id("de.fabmax.webidl-util") version "0.9.0"
 }
 
 kotlin {
@@ -21,5 +23,17 @@ kotlin {
             api(npm(libs.physxjswebidl.get().name, libs.versions.physxjswebidl.get()))
 //            api(npm(File("$projectDir/npm/physx-js-webidl")))
         }
+    }
+}
+
+webidl {
+    localProperties["physx-js.webidldir"]?.let { modelPath = file(it) }
+    modelName = "PhysXJs"
+
+    generateKotlinJsInterfaces {
+        outputDirectory = file("${projectDir}/src/jsMain/kotlin/physx")
+        packagePrefix = "physx"
+        moduleName = "physx-js-webidl"
+        modulePromiseName = "PhysX"
     }
 }


### PR DESCRIPTION
Use the webidl-util gradle plugin to generate kotlin/js bindings to physx