### PR TITLE
Fix vector `yz` swizzle

### DIFF
--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorB3.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorB3.kt
@@ -12,7 +12,7 @@ val KslExpression<KslBool3>.b get() = bool1("b")
 
 val KslExpression<KslBool3>.xy get() = bool2("xy")
 val KslExpression<KslBool3>.xz get() = bool2("xz")
-val KslExpression<KslBool3>.yz get() = bool2("xz")
+val KslExpression<KslBool3>.yz get() = bool2("yz")
 
 val KslExpression<KslBool3>.rg get() = bool2("rg")
 val KslExpression<KslBool3>.rb get() = bool2("rb")

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorB4.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorB4.kt
@@ -14,7 +14,7 @@ val KslExpression<KslBool4>.a get() = bool1("a")
 
 val KslExpression<KslBool4>.xy get() = bool2("xy")
 val KslExpression<KslBool4>.xz get() = bool2("xz")
-val KslExpression<KslBool4>.yz get() = bool2("xz")
+val KslExpression<KslBool4>.yz get() = bool2("yz")
 
 val KslExpression<KslBool4>.rg get() = bool2("rg")
 val KslExpression<KslBool4>.rb get() = bool2("rb")

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorF3.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorF3.kt
@@ -12,7 +12,7 @@ val KslExpression<KslFloat3>.b get() = float1("b")
 
 val KslExpression<KslFloat3>.xy get() = float2("xy")
 val KslExpression<KslFloat3>.xz get() = float2("xz")
-val KslExpression<KslFloat3>.yz get() = float2("xz")
+val KslExpression<KslFloat3>.yz get() = float2("yz")
 
 val KslExpression<KslFloat3>.rg get() = float2("rg")
 val KslExpression<KslFloat3>.rb get() = float2("rb")

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorF4.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorF4.kt
@@ -14,7 +14,7 @@ val KslExpression<KslFloat4>.a get() = float1("a")
 
 val KslExpression<KslFloat4>.xy get() = float2("xy")
 val KslExpression<KslFloat4>.xz get() = float2("xz")
-val KslExpression<KslFloat4>.yz get() = float2("xz")
+val KslExpression<KslFloat4>.yz get() = float2("yz")
 val KslExpression<KslFloat4>.xw get() = float2("xw")
 val KslExpression<KslFloat4>.yw get() = float2("yw")
 val KslExpression<KslFloat4>.zw get() = float2("zw")

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorI3.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorI3.kt
@@ -12,7 +12,7 @@ val KslExpression<KslInt3>.b get() = int1("b")
 
 val KslExpression<KslInt3>.xy get() = int2("xy")
 val KslExpression<KslInt3>.xz get() = int2("xz")
-val KslExpression<KslInt3>.yz get() = int2("xz")
+val KslExpression<KslInt3>.yz get() = int2("yz")
 
 val KslExpression<KslInt3>.rg get() = int2("rg")
 val KslExpression<KslInt3>.rb get() = int2("rb")

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorI4.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorI4.kt
@@ -14,7 +14,7 @@ val KslExpression<KslInt4>.a get() = int1("a")
 
 val KslExpression<KslInt4>.xy get() = int2("xy")
 val KslExpression<KslInt4>.xz get() = int2("xz")
-val KslExpression<KslInt4>.yz get() = int2("xz")
+val KslExpression<KslInt4>.yz get() = int2("yz")
 
 val KslExpression<KslInt4>.rg get() = int2("rg")
 val KslExpression<KslInt4>.rb get() = int2("rb")

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorU3.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorU3.kt
@@ -12,7 +12,7 @@ val KslExpression<KslUint3>.b get() = uint1("b")
 
 val KslExpression<KslUint3>.xy get() = uint2("xy")
 val KslExpression<KslUint3>.xz get() = uint2("xz")
-val KslExpression<KslUint3>.yz get() = uint2("xz")
+val KslExpression<KslUint3>.yz get() = uint2("yz")
 
 val KslExpression<KslUint3>.rg get() = uint2("rg")
 val KslExpression<KslUint3>.rb get() = uint2("rb")

--- a/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorU4.kt
+++ b/kool-core/src/commonMain/kotlin/de/fabmax/kool/modules/ksl/lang/KslVectorAccessorU4.kt
@@ -14,7 +14,7 @@ val KslExpression<KslUint4>.a get() = uint1("a")
 
 val KslExpression<KslUint4>.xy get() = uint2("xy")
 val KslExpression<KslUint4>.xz get() = uint2("xz")
-val KslExpression<KslUint4>.yz get() = uint2("xz")
+val KslExpression<KslUint4>.yz get() = uint2("yz")
 
 val KslExpression<KslUint4>.rg get() = uint2("rg")
 val KslExpression<KslUint4>.rb get() = uint2("rb")


### PR DESCRIPTION
We should really be looking into something more reliable. 😅 

Btw, I've been working on a meta-coding tool for my projects (Python spatial math library [Spatium](https://github.com/shBLOCK/spatium) and a Kotlin Minecraft project I haven't released yet).
It's a Python tool, but it's designed to support generating code in any language, with Python, Cython, and Kotlin being the primary focus.
If you are okay with some Python codegen scripts in Kool, I can look into implementing some codegen for Kool later.
